### PR TITLE
update env variables to be generic names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /obj
 /nuget
 *.env
+.vs

--- a/Program.cs
+++ b/Program.cs
@@ -18,18 +18,15 @@ namespace Laserfiche.Repository.Api.Client.Sample.ServiceApp
             }
 
             // Read credentials from envrionment
-            var servicePrincipalKey = Environment.GetEnvironmentVariable("DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY");
-            var base64EncodedAccessKey = Environment.GetEnvironmentVariable("DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY");
-            if (base64EncodedAccessKey != null)
-            {
-                var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(base64EncodedAccessKey));
-                Environment.SetEnvironmentVariable("DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY", decoded);
-            } else
+            var servicePrincipalKey = Environment.GetEnvironmentVariable("SERVICE_PRINCIPAL_KEY");
+            var base64EncodedAccessKey = Environment.GetEnvironmentVariable("ACCESS_KEY");
+            if (base64EncodedAccessKey == null)
             {
                 throw new InvalidOperationException("Cannot continue due to missing access key.");
             }
-            var accessKey = JsonConvert.DeserializeObject<AccessKey>(Environment.GetEnvironmentVariable("DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY"));
-            var repositoryId = Environment.GetEnvironmentVariable("DEV_CA_PUBLIC_USE_REPOSITORY_ID_1");
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(base64EncodedAccessKey));
+            var accessKey = JsonConvert.DeserializeObject<AccessKey>(decoded);
+            var repositoryId = Environment.GetEnvironmentVariable("REPOSITORY_ID");
 
             // Create the client
             var repoClient = RepositoryApiClient.Create(servicePrincipalKey, accessKey);

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ dotnet run
 
 ### Add dependencies
 
-```
-dotnet add package Laserfiche.Oauth.Api.Client --version 2.0.0
-```
 (Currently, we have not yet released the 2.0 version (but will be soon), for now, we can use a local nuget package using command similar to the one below.)
 
 ```

--- a/lf-sample-repository-api-dotnet-srv.csproj
+++ b/lf-sample-repository-api-dotnet-srv.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="2.3.0" />
-    <PackageReference Include="Laserfiche.Api.Client.Core" Version="1.0.1-beta.1" />
     <PackageReference Include="Laserfiche.Repository.Api.Client" Version="1.0.1-beta.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>


### PR DESCRIPTION
- remove explicit dependency on Laserfiche.Api.Client.Core because this is already a dependency in Laserfiche.Repository.Api.Client
- Update env variable names to be more generic