### PR TITLE
Fix readme and use space as separator in scopes in code.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,11 @@ name: lf-sample-repository-api-dotnet-srv-CI
 
 on:
   push:
-    branches: [ '\d+.x' ]
+    branches:
+      - v1
   pull_request:
-    branches: [ '\d+.x' ]
+    branches:
+      - v1
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/Program.cs
+++ b/Program.cs
@@ -21,7 +21,7 @@ namespace Laserfiche.Repository.Api.Client.Sample.ServiceApp
                 IRepositoryApiClient client;
 
                 // Scope(s) requested by the app
-                string scope = "repository.Read,repository.Write";
+                string scope = "repository.Read repository.Write";
                 if (config.AuthorizationType == AuthorizationType.CLOUD_ACCESS_KEY)
                 {
                     client = RepositoryApiClient.CreateFromAccessKey(config.ServicePrincipalKey, config.AccessKey, scope);

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Sample .NET core service app that connects to a Laserfiche Cloud or Self-Hosted 
   - [EU Cloud](https://app.eu.laserfiche.com/laserfiche)
   - [US Cloud](https://app.laserfiche.com/laserfiche)
 
-- Using the app picker, go to the 'Account' page
-- Click on the 'Service Principals' tab
-- Click on the 'Add Service Principal' button to create an account to be used to run this sample service
-- Add access rights to the repository and click the 'Create' button
-- View the created service principal and click on the 'Create Service Principal Key(s)' button
-- Save the Service Principal Key for later use
+- Using the app picker, go to the 'Account' page.
+- Click on the 'Service Principals' tab.
+- Click on the 'Add Service Principal' button to create an account to be used to run this sample service.
+- Add access rights to the repository and click the 'Create' button.
+- View the created service principal and click on the 'Create Service Principal Key(s)' button.
+- Save the Service Principal Key for later use.
 
 ### 2. Create an OAuth Service App
 
@@ -31,19 +31,25 @@ Sample .NET core service app that connects to a Laserfiche Cloud or Self-Hosted 
   - [CA Cloud](https://app.laserfiche.ca/devconsole/)
   - [EU Cloud](https://app.eu.laserfiche.com/devconsole/)
   - [US Cloud](https://app.laserfiche.com/devconsole/)
-- Click on the 'New' button and choose the 'Create a new app' option
-- Select the 'Service' option, enter a name, and click the 'Create application' button
-- Select the app service account to be the one created on step 1 and click the 'Save changes' button
-- Click on the 'Authentication' Tab and create a new Access Key
-- Select the first option (i.e. Create a public 'Access Key'...)
-- Click the 'Download key as base-64 string' button for later use
-- Click OK
+- Click on the 'New' button and choose the 'Create a new app' option.
+- Select the 'Service' option, enter a name, and click the 'Create application' button.
+- Select the app service account to be the one created on step 1 and click the 'Save changes' button.
+- Click on the 'Authentication' Tab and create a new Access Key.
+- Select the first option (i.e. Create a public 'Access Key'...).
+- Click the 'Download key as base-64 string' button for later use.
+- Click OK.
+- Select the required scope(s) in the 'Authentication' tab. For running this sample project, both 'repository.Read' and 'repository.Write' scopes are required.
+- Click on the 'Update scopes' button.
 
-### 3. Clone this repo on your local machine
+### 3. Clone this repo on your local 
+
+```
+git clone -b v1 https://github.com/Laserfiche/lf-sample-repository-api-dotnet-srv.git
+```
 
 ### 4. Create a .env file
 
-- Using the app picker, go to the 'Repository Administration' page and copy the Repository ID
+- Using the app picker, go to the 'Repository Administration' page and copy the Repository ID.
 - In the root directory of this project, create a .env file containing the following lines:
 ```
 AUTHORIZATION_TYPE="CLOUD_ACCESS_KEY" 
@@ -54,8 +60,8 @@ ACCESS_KEY="<base-64 Access Key string created from step 2>"
 
 REPOSITORY_ID="<Repository ID from the 'Repository Administration' page>"
 ```
-- Note: The .env file is used in local development environment to set operating system environment variables. DO NOT
-  check-in the .env file in Git
+- Note: The .env file is used in local development environment to set operating system environment variables.
+  - DO NOT check-in the .env file in Git.
 
 ## Self-Hosted Prerequisites
 
@@ -65,6 +71,10 @@ REPOSITORY_ID="<Repository ID from the 'Repository Administration' page>"
 - Set up Self-Hosted API Server 1.0+
 
 ### 1. Clone this repo on your local machine
+
+```
+git clone -b v1 https://github.com/Laserfiche/lf-sample-repository-api-dotnet-srv.git
+```
 
 ### 2. Create a .env file
 
@@ -81,12 +91,12 @@ APISERVER_PASSWORD="<Password>"
 
 APISERVER_REPOSITORY_API_BASE_URL="<API Server Base Url (ex: https://example.com/LFRepositoryAPI)>"
 ```
-- Note: The .env file is used in local development environment to set operating system environment variables. DO NOT
-  check-in the .env file in Git
+- Note: The .env file is used in local development environment to set operating system environment variables.
+  - DO NOT check-in the .env file in Git.
 
 ## Build and Run this App
 
-- Open a terminal window
+- Open a terminal window.
 - Enter the following commands:
 
 ```csharp
@@ -95,4 +105,4 @@ dotnet run
 ```
 
 These commands will install, compile, and execute this program which will print out the repository information in the output window.
-Note: This project uses the [Laserfiche.Repository.Api.Client NuGet package](https://www.nuget.org/packages/Laserfiche.Repository.Api.Client). See [Laserfiche Repository API Documentation](https://developer.laserfiche.com/libraries.html).
+Note: This project uses the [Laserfiche.Repository.Api.Client](https://www.nuget.org/packages/Laserfiche.Repository.Api.Client) NuGet package. See [Laserfiche Repository API Documentation](https://developer.laserfiche.com/libraries.html).


### PR DESCRIPTION
Fix readme to mention scopes.
Add dots at the end of paragraphs.
As this is not the default branch, hint the user for cloning the repository.