### PR TITLE
Correct spelling of `environment` in ServiceConfig.cs comment

### DIFF
--- a/ServiceConfig.cs
+++ b/ServiceConfig.cs
@@ -32,7 +32,7 @@ namespace Laserfiche.Repository.Api.Client.Sample.ServiceApp
                 Console.WriteLine("Failed to read credentials.");
             }
 
-            // Read credentials from envrionment
+            // Read credentials from environment
             if (Enum.TryParse(Environment.GetEnvironmentVariable(AUTHORIZATION_TYPE), ignoreCase: true, out AuthorizationType value))
             {
                 AuthorizationType = value;


### PR DESCRIPTION
This is for V1 branch.
Correct spelling of `envrionment` to `environment`.